### PR TITLE
Linux/Macに対応

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.15)
 
 project(MemoryPatching VERSION 1.0)
 
-# android | iOS | Windows
+# Android | iOS | Windows | Linux | Darwin
 set(CMAKE_SYSTEM_NAME android)
 
 add_library(cxx_flags INTERFACE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 project(MemoryPatching VERSION 1.0)
 
 # Android | iOS | Windows | Linux | Darwin
-set(CMAKE_SYSTEM_NAME android)
+set(CMAKE_SYSTEM_NAME Android)
 
 add_library(cxx_flags INTERFACE)
 target_compile_features(cxx_flags INTERFACE cxx_std_14)

--- a/README.md
+++ b/README.md
@@ -29,13 +29,22 @@ $ ~/Library/Android/sdk/ndk/VERSION/ndk-build
 
 ### CMakeを使用してビルドする
 
-buildディレクトリを作り、buildディレクトリの中でcmakeコマンドを以下のように実行します。
+buildディレクトリを作り、buildディレクトリの中でcmakeコマンドを以下のように実行します(Windows以外)。
 
 ```
 $ mkdir build
 $ cd build
 $ cmake -DCMAKE_TOOLCHAIN_FILE=/path/to/ndk/build/cmake/android.toolchain.cmake -DANDROID_ABI=arm64-v8a ..
 $ make -j8
+```
+
+Windowsの場合、[Ninja](https://github.com/ninja-build/ninja)をインストールしてビルドします。
+
+```
+$ mkdir build
+$ cd build
+$ cmake -G "Ninja" -DCMAKE_TOOLCHAIN_FILE=/path/to/ndk/build/cmake/android.toolchain.cmake -DANDROID_ABI=arm64-v8a ..
+$ ninja
 ```
 
 上記コマンドが成功すると、build/jni/mempatchという実行ファイルが生成されます。

--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -9,7 +9,7 @@ set(SOURCE_FILES
     SnappedRange.cpp
 )
 
-if (CMAKE_SYSTEM_NAME STREQUAL "android")
+if (CMAKE_SYSTEM_NAME STREQUAL "Android")
     list(APPEND SOURCE_FILES
         Memory_Linux.cpp
         linenoise/linenoise.cpp
@@ -26,6 +26,18 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Windows")
         getopt.cpp
         Memory_Windows.cpp
         LineReader_Windows.cpp
+    )
+elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    list(APPEND SOURCE_FILES
+        Memory_Linux.cpp
+        linenoise/linenoise.cpp
+        LineReader.cpp
+    )
+elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    list(APPEND SOURCE_FILES
+        Memory_Darwin.mm
+        linenoise/linenoise.cpp
+        LineReader.cpp
     )
 endif()
 

--- a/jni/main.cpp
+++ b/jni/main.cpp
@@ -33,7 +33,9 @@ void Usage(const char *exepath) {
   fprintf(stderr, "Version: mempatch v%s\n", VERSION);
   fprintf(stderr, "Options:\n");
   fprintf(stderr, "  -h        Print this message\n");
+#ifdef __linux__
   fprintf(stderr, "  -w        Without ptrace\n");
+#endif
   fprintf(stderr, "  -l        Windows mode\n");
   fprintf(stderr, "  -p pid    Set process ID to attach\n");
   fprintf(stderr, "\n");


### PR DESCRIPTION
Your content here


- [x ] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).

1. Linux/Macに対応しました。
1. Windowsでのcmakeを用いてAndroid版のビルド方法として、Ninjaを使う例を記載しました。


## ビルド方法
Linux/Mac共に下記でビルド可能です。

1. CMakeLists.txtの書き換え
set(CMAKE_SYSTEM_NAME Android)
=> AndroidをLinux or Darwinに変更。

2. ビルド
```
$ mkdir build
$ cd build
$ cmake ..
$ make
```

